### PR TITLE
remove unused factory: TokensByCategory

### DIFF
--- a/public/services/tokens.js
+++ b/public/services/tokens.js
@@ -10,14 +10,3 @@ angular.module('mean.system').factory('Tokens', ['$resource', function($resource
         }
     });
 }]);
-
-//Tokens service used for tokens REST endpoint
-angular.module('mean.system').factory('TokensByCategory', ['$resource', function($resource) {
-    return $resource('tokens/category/:category', {
-        title: '@category'
-    }, {
-        update: {
-            method: 'PUT'
-        }
-    });
-}]);


### PR DESCRIPTION
It looks like the TokensByCategory is not used. The category filter is done by angular?
remove unused factory: TokensByCategory
